### PR TITLE
Added option to remove/cancel file upload on failed uploads.

### DIFF
--- a/src/components/FileUpload/FileUploadResults.tsx
+++ b/src/components/FileUpload/FileUploadResults.tsx
@@ -41,7 +41,7 @@ const FileUploadResultsInner = <Response = string,>(
       </Grow>
     ))}
     {failed.map((f) => (
-      <FileUploadCard key={f.id} fileUpload={f} actions={<FileUploadCardActions onRetry={() => onRetry?.(f)} />} />
+      <FileUploadCard key={f.id} fileUpload={f} actions={<FileUploadCardActions onRemove={() => onRemoveFileUpload?.(f)} onRetry={() => onRetry?.(f)} />} />
     ))}
     {inProgress.map((f) => (
       <Fade in={true} key={f.id}>


### PR DESCRIPTION
I noticed that on failed file uploads there is only the option of retry. I add a simple line to include canceling or deleting the current upload.

## Things done
- Added on remove function to FileUploadCardActions

## Test / Demo

![Demo](https://github.com/NicholasMata/mui-file-upload/assets/87546813/33a43472-b95b-4eb2-b348-7b4735969c38)


