### PR TITLE
Added new customization options

### DIFF
--- a/src/components/FileDropzone/FileDropzoneBody.tsx
+++ b/src/components/FileDropzone/FileDropzoneBody.tsx
@@ -4,6 +4,7 @@ import { FileDropzoneStatusUtils } from '../../utils';
 import { useFileDropzoneContext } from './hooks';
 import { type ReactNode, useMemo } from 'react';
 import {
+  DEFAULT_BROWSE_FILES_TITLE,
   DEFAULT_FILE_DRAG_REJECTED_TITLE,
   DEFAULT_FILE_DROPZONE_DISABLED,
   DEFAULT_FILE_OVERLOAD_TITLE,
@@ -15,6 +16,8 @@ import { FileDropzoneStatus } from './types';
 export type FileDropzoneBodyProps = {
   /** The default title of the zone. */
   title?: ReactNode;
+  /** The title of the button that will open the file selector dialog. */
+  openFileSelectorTitle?: ReactNode;
   /**
    * The title of the zone that will be displayed when something can be dropped on it.
    */
@@ -33,6 +36,7 @@ export const FileDropzoneBody = (props: FileDropzoneBodyProps): JSX.Element => {
 
   const {
     title: normalTitle = getDefaultBodyTitle(allowsMultiple),
+    openFileSelectorTitle = DEFAULT_BROWSE_FILES_TITLE,
     dropTitle = getDefaultDropBodyTitle(allowsMultiple),
     fileOverloadTitle = DEFAULT_FILE_OVERLOAD_TITLE,
     dragRejectedTitle = DEFAULT_FILE_DRAG_REJECTED_TITLE,
@@ -122,7 +126,7 @@ export const FileDropzoneBody = (props: FileDropzoneBodyProps): JSX.Element => {
         onClick={openFileSelector}
         className='upload-button'
       >
-        Browse files
+        {openFileSelectorTitle}
       </Button>
     </Stack>
   );

--- a/src/components/FileDropzone/FileDropzoneInputBody.tsx
+++ b/src/components/FileDropzone/FileDropzoneInputBody.tsx
@@ -2,6 +2,7 @@ import { Link, type SxProps, type Theme, Typography } from '@mui/material';
 import { type ReactNode, useMemo } from 'react';
 import { useFileDropzoneContext } from './hooks';
 import {
+  DEFAULT_CLICK_TO_UPLOAD_TITLE,
   DEFAULT_FILE_DRAG_REJECTED_TITLE,
   DEFAULT_FILE_DROPZONE_DISABLED,
   DEFAULT_FILE_OVERLOAD_TITLE,
@@ -14,6 +15,8 @@ import { FileDropzoneStatusUtils } from '../../utils';
 export type FileDropzoneInputBodyProps = {
   /** The title of the input. Will be prefixed with "Click to upload " */
   title?: ReactNode;
+  /** The title of the button that will open the file selector dialog. */
+  openFileSelectorTitle?: ReactNode;
   /**
    * The title of the input that will be displayed when something can be dropped on it.
    * Will be prefixed with "Click to upload "
@@ -34,6 +37,7 @@ export const FileDropzoneInputBody = (props: FileDropzoneInputBodyProps): JSX.El
   const { disabled } = dropzoneState;
   const {
     title = `or ${getDefaultBodyTitle(allowsMultiple).toLowerCase()}`,
+    openFileSelectorTitle = DEFAULT_CLICK_TO_UPLOAD_TITLE,
     dropTitle = `or ${getDefaultDropBodyTitle(allowsMultiple).toLowerCase()}`,
     fileOverloadTitle = DEFAULT_FILE_OVERLOAD_TITLE,
     dragRejectedTitle = DEFAULT_FILE_DRAG_REJECTED_TITLE,
@@ -73,7 +77,7 @@ export const FileDropzoneInputBody = (props: FileDropzoneInputBodyProps): JSX.El
     >
       {!isError && !disabled && (
         <Link sx={{ cursor: 'pointer' }} onClick={openFileSelector}>
-          Click to upload
+          {openFileSelectorTitle}
         </Link>
       )}{' '}
       {titleComponent}

--- a/src/components/FileDropzone/contants.ts
+++ b/src/components/FileDropzone/contants.ts
@@ -4,6 +4,10 @@ export const getDefaultBodyTitle = (allowsMultiple: boolean): string =>
 export const getDefaultDropBodyTitle = (allowsMultiple: boolean): string =>
   `Drop the file${allowsMultiple ? 's' : ''} to start uploading`;
 
+export const DEFAULT_BROWSE_FILES_TITLE = 'Browse files';
+
+export const DEFAULT_CLICK_TO_UPLOAD_TITLE = 'Click to upload';
+
 export const DEFAULT_FILE_OVERLOAD_TITLE = 'Too many files have been dragged';
 
 export const DEFAULT_FILE_DRAG_REJECTED_TITLE = 'Dragged files have invalid file type';

--- a/src/components/FileUpload/FileUploadResults.tsx
+++ b/src/components/FileUpload/FileUploadResults.tsx
@@ -19,6 +19,12 @@ type Props<Response = string> = {
   onRetry?: (fileUpload: FileUpload<Response>) => void;
   /** Called when a file upload needs to be removed. */
   onRemoveFileUpload?: (fileUpload: FileUpload<Response>) => void;
+  /**
+   * Returns a custom status label for a file upload e.g. "Uploading", "Failed" or "Completed".
+   * @param fileUpload File upload for which the status should be formatted
+   * @returns Status label for the file upload
+   */
+  statusFormatter?: (fileUpload: FileUpload<Response>) => string;
 } & StackProps;
 
 const FileUploadResultsInner = <Response = string,>(
@@ -30,6 +36,7 @@ const FileUploadResultsInner = <Response = string,>(
     onDismissRejected,
     onRetry,
     onRemoveFileUpload,
+    statusFormatter,
     ...stackProps
   }: Props<Response>,
   ref?: Ref<HTMLDivElement>
@@ -45,12 +52,13 @@ const FileUploadResultsInner = <Response = string,>(
         key={f.id}
         fileUpload={f}
         actions={<FileUploadCardActions onRemove={() => onRemoveFileUpload?.(f)} onRetry={() => onRetry?.(f)} />}
+        statusFormatter={statusFormatter}
       />
     ))}
     {inProgress.map((f) => (
       <Fade in={true} key={f.id}>
         <Box>
-          <FileUploadCard fileUpload={f} />
+          <FileUploadCard fileUpload={f} statusFormatter={statusFormatter} />
         </Box>
       </Fade>
     ))}
@@ -59,6 +67,7 @@ const FileUploadResultsInner = <Response = string,>(
         fileUpload={f}
         key={f.id}
         actions={<FileUploadCardActions onRemove={() => onRemoveFileUpload?.(f)} />}
+        statusFormatter={statusFormatter}
       />
     ))}
   </Stack>

--- a/src/components/FileUpload/MultiFileUpload.stories.tsx
+++ b/src/components/FileUpload/MultiFileUpload.stories.tsx
@@ -16,6 +16,7 @@ type StoryProps = {
   title: string;
   dropTitle: string;
   disabledTitle: string;
+  openFileSelectorTitle: string;
 };
 
 type AllProps = ComponentProps<typeof MultiFileUpload<void>> & StoryProps;
@@ -55,6 +56,7 @@ export const CustomTitle: Story = {
     title: 'Custom Title Text',
     dropTitle: 'Custom Drop Text',
     disabledTitle: 'Custom Disabled Text',
+    openFileSelectorTitle: 'Custom Browse Files Text',
   },
   render: (args) => {
     const uploadService = useFakeService({ failureRate: args.failureRate });
@@ -67,6 +69,7 @@ export const CustomTitle: Story = {
             title={args.title}
             dropTitle={<Typography>{args.dropTitle}</Typography>}
             disabledTitle={args.disabledTitle}
+            openFileSelectorTitle={args.openFileSelectorTitle}
           />
         }
         uploadService={uploadService}

--- a/src/components/FileUpload/MultiFileUpload.tsx
+++ b/src/components/FileUpload/MultiFileUpload.tsx
@@ -10,7 +10,18 @@ export type MultiFileUploadProps<Response = string> = BaseFileUploadProps<Respon
 const MemoizedFileDropzone = memo(FileDropzone);
 
 export const MultiFileUpload = <Response = string,>(props: MultiFileUploadProps<Response>): JSX.Element => {
-  const { uploadService, acceptsOnly, onSuccessfulUpload, fileManager, body, sx, disabled, error, helperText } = props;
+  const {
+    uploadService,
+    acceptsOnly,
+    onSuccessfulUpload,
+    fileManager,
+    body,
+    sx,
+    disabled,
+    error,
+    helperText,
+    statusFormatter,
+  } = props;
   const { rejectedFiles, addRejected, removeRejected } = useRejectedFileManager();
 
   const { fileUploads, removeFileUpload, handlers } = fileManager ?? useFileUploadManager<Response>();
@@ -53,6 +64,7 @@ export const MultiFileUpload = <Response = string,>(props: MultiFileUploadProps<
           onRetry={upload}
           onDismissRejected={removeRejected}
           onRemoveFileUpload={removeFileUpload}
+          statusFormatter={statusFormatter}
         />
       )}
     </Stack>

--- a/src/components/FileUpload/SingleFileUpload.stories.tsx
+++ b/src/components/FileUpload/SingleFileUpload.stories.tsx
@@ -18,6 +18,7 @@ type StoryProps = {
   title: string;
   dropTitle: string;
   disabledTitle: string;
+  openFileSelectorTitle: string;
 };
 
 type AllProps = ComponentProps<typeof SingleFileUpload<string>> & StoryProps;
@@ -64,6 +65,7 @@ export const CustomTitle: Story = {
     title: 'Custom Title Text',
     dropTitle: 'Custom Drop Text',
     disabledTitle: 'Custom Disabled Text',
+    openFileSelectorTitle: 'Custom Open File Browser',
   },
 
   render: (args) => {
@@ -75,9 +77,10 @@ export const CustomTitle: Story = {
         sx={{ dragZoneSx: () => ({ borderStyle: 'solid', borderWidth: 1, borderRadius: 0 }) }}
         body={
           <FileDropzoneInputBody
-            title='Custom text here'
-            dropTitle='Custom drop text here'
-            disabledTitle='Custom disabled text here'
+            title={args.title}
+            dropTitle={args.dropTitle}
+            disabledTitle={args.disabledTitle}
+            openFileSelectorTitle={args.openFileSelectorTitle}
           />
         }
         acceptsOnly={args.acceptsOnly}

--- a/src/components/FileUpload/SingleFileUpload.tsx
+++ b/src/components/FileUpload/SingleFileUpload.tsx
@@ -16,6 +16,7 @@ export const SingleFileUpload = <Response = string,>(props: SingleFileUploadProp
     body = <FileDropzoneInputBody />,
     sx,
     disabled,
+    statusFormatter,
   } = props;
   const { rejectedFiles, addRejected, removeRejected } = useRejectedFileManager();
 
@@ -71,6 +72,7 @@ export const SingleFileUpload = <Response = string,>(props: SingleFileUploadProp
           onRetry={upload}
           onDismissRejected={removeRejected}
           onRemoveFileUpload={removeFileUpload}
+          statusFormatter={statusFormatter}
         />
       </Fade>
     </Box>

--- a/src/components/FileUpload/types.ts
+++ b/src/components/FileUpload/types.ts
@@ -10,6 +10,12 @@ export type BaseFileUploadProps<Response = string> = {
   uploadService: FileUploadService<Response>;
   /** Called when a upload was successful. If this is provided then successful file uploads need to be rendered externally. */
   onSuccessfulUpload?: (fileUpload: FileUpload<Response>) => void;
+  /**
+   * Returns a custom status label for a file upload e.g. "Uploading", "Failed" or "Completed".
+   * @param fileUpload File upload for which the status should be formatted
+   * @returns Status label for the file upload
+   */
+  statusFormatter?: (fileUpload: FileUpload<Response>) => string;
   /** A file manager responsible for handling different states.  */
   fileManager?: FileUploadManager<Response>;
   /** A accept string which states which file types are allowed to be uploaded. */

--- a/src/components/FileUploadCard/FileUploadCard.tsx
+++ b/src/components/FileUploadCard/FileUploadCard.tsx
@@ -12,6 +12,12 @@ export type FileUploadCardProps<FileUploadResponse = string> = {
   /** The FileUpload that will be used to build the card. */
   fileUpload: FileUpload<FileUploadResponse>;
   actions?: ReactNode;
+  /**
+   * Returns a custom status label for a file upload e.g. "Uploading", "Failed" or "Completed".
+   * @param fileUpload File upload for which the status should be formatted
+   * @returns Status label for the file upload
+   */
+  statusFormatter?: (fileUpload: FileUpload<FileUploadResponse>) => string;
 };
 
 export const FileUploadCard = <FileUploadResponse = string,>({
@@ -19,8 +25,9 @@ export const FileUploadCard = <FileUploadResponse = string,>({
   fileUpload,
   variant = 'outlined',
   actions,
+  statusFormatter,
 }: FileUploadCardProps<FileUploadResponse>): JSX.Element => {
-  const status = FileUploadUtils.formatStatus(fileUpload);
+  const status = (statusFormatter ?? FileUploadUtils.formatStatus)(fileUpload);
 
   return (
     <Card variant={variant}>
@@ -29,7 +36,7 @@ export const FileUploadCard = <FileUploadResponse = string,>({
         title={fileUpload.file.name}
         subheader={
           <Stack>
-            <Typography variant='caption' color={status === 'Failed' ? 'error' : 'text.secondary'}>
+            <Typography variant='caption' color={fileUpload.failed === true ? 'error' : 'text.secondary'}>
               {FileUtils.formatFileSize(fileUpload.file.size)} · {status}
             </Typography>
             {!fileUpload.completed ? (

--- a/website/docs/components/advanced/FileDropzoneBody.mdx
+++ b/website/docs/components/advanced/FileDropzoneBody.mdx
@@ -24,6 +24,7 @@ export const Component = () => {
     body={
       <FileDropzoneBody
         title='Custom Title'
+        openFileSelectorTitle='Custom Browse Files Title'
         dropTitle='Custom Drop Title'
         disabledTitle='Custom Disabled Title'
         dragRejectedTitle='Custom Rejected Title'

--- a/website/docs/components/advanced/FileDropzoneInputBody.mdx
+++ b/website/docs/components/advanced/FileDropzoneInputBody.mdx
@@ -24,6 +24,7 @@ export const Component = () => {
     body={
       <FileDropzoneInputBody
         title='or Custom Title'
+        openFileSelectorTitle='Custom Click to Upload'
         dropTitle='or Custom Drop Title'
         disabledTitle='Custom Disabled Title'
         dragRejectedTitle='Custom Rejected Title'

--- a/website/docs/components/advanced/_FileDropzoneBodyProps.md
+++ b/website/docs/components/advanced/_FileDropzoneBodyProps.md
@@ -5,6 +5,12 @@
 > Default: **"Drag the file here to start uploading" | "Drag the files here to start uploading"** <br/>
 > <sub>The pluralization is based on if used FileDropzone allowsMultiple is set to true.</sub>
 
+#### openFileSelectorTitle <sup>ReactNode</sup>
+
+> The title of the button that will open the file selector dialog
+>
+> Default: **"Click to upload" | "Browse files"**
+
 #### dropTitle <sup>ReactNode</sup>
 
 > The title of the zone that will be displayed when something can be dropped on it

--- a/website/docs/components/basics/_FileUploadOptionalProps.md
+++ b/website/docs/components/basics/_FileUploadOptionalProps.md
@@ -42,3 +42,7 @@ All the following props are optional meaning they can be undefined.
 >
 > Default: **undefined**<br/>
 
+#### statusFormatter <sup>(fileUpload: FileUpload\<Response\>) => string</sup>
+> Returns a custom status label for a file upload e.g. "Uploading", "Failed" or "Completed".
+>
+> Default: **undefined**<br/>


### PR DESCRIPTION
As the library is currently only usable for english applications because of the hardcoded english titles, I added some more customization options 

Following labels can now be customized:
- the title of the open file selector button
- the title of the file upload status